### PR TITLE
fix: working button after blocked upload

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -129,12 +129,12 @@
       const uploadButton = document.querySelector('.upload-btn');
       const fileChooser = document.getElementById('upload-file-chooser-text');
 
-      function getExtension(filename) {
+      const getExtension = (filename) => {
         var parts = filename.split('.');
         return parts[parts.length - 1];
       }
 
-      function isImage(filename) {
+      const isImage = (filename) => {
         var ext = getExtension(filename);
         switch (ext.toLowerCase()) {
           case 'jpg':
@@ -153,21 +153,21 @@
       }
 
       imagefile.onchange = (event) => {
+        const filename = imagefile.files[0].name;
+        if (!isImage(getExtension(filename))) {
+          alert('Only image files are allowed!');
+          imagefile.files = null;
+          return;
+        }
+
         loadFile(event);
         predHolder.innerText = 'upload an image to predict what it is';
         fileChooser.innerText = 'working';
         imagefile.disabled = true;
         uploadButton.classList.toggle('is-dark');
         uploadButton.classList.toggle('is-danger');
+
         const formData = new FormData();
-
-        const filename = imagefile.files[0].name;
-        if(!isImage(getExtension(filename))){
-          alert('Only image files are allowed!');
-          imagefile.files = null;
-          return;
-        }
-
         formData.append('file', imagefile.files[0]);
         axios
           .post('/', formData, {


### PR DESCRIPTION
Changing the order of the guard clause as in #27 fixes the bug where a blocked upload (non-image) still results in the text and color of the button to change to the `working` state.

![demoBruteForce2](https://user-images.githubusercontent.com/11232940/95039061-5cddfd00-06ed-11eb-8d8f-21a41cc852d0.gif)
